### PR TITLE
Adjust joinscript for displaying owncloud as an App-Tab in UCS 4.4

### DIFF
--- a/03-join.sh
+++ b/03-join.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # join
 # outer script
-VERSION=2
+VERSION=3
 SERVICE="ownCloud"
 
 . /usr/share/univention-join/joinscripthelper.lib
@@ -13,6 +13,13 @@ eval "$(ucr shell)"
 
 ucs_addServiceToLocalhost ${SERVICE} "$@" || die
 ICON_PATH="/univention/js/dijit/themes/umc/icons/scalable/apps-"$(univention-app get owncloud component_id --values-only)".svg"
+
+ICON_USER="/usr/share/univention-management-console-frontend/js/dijit/themes/umc/icons/scalable/owncloudUser.svg"
+ICON_GROUP="/usr/share/univention-management-console-frontend/js/dijit/themes/umc/icons/scalable/owncloudGroup.svg"
+[ -e "$ICON_USER" ] && rm "$ICON_USER"
+ln -s "apps-$(univention-app get owncloud component_id --values-only)".svg "$ICON_USER"
+[ -e "$ICON_GROUP" ] && rm "$ICON_GROUP"
+ln -s "apps-$(univention-app get owncloud component_id --values-only)".svg "$ICON_GROUP"
 
 echo "[03.JOIN] Creating ownCloud admin docs..."
 OVBASE="ucs/web/overview/entries/admin/owncloud-admindoc"
@@ -38,95 +45,6 @@ ucr set \
 
 ucs_unregisterLDAPExtension "$@" --schema owncloud
 joinscript_register_schema "$@" || die
-
-univention-directory-manager container/cn create "$@" --ignore_exists \
-  --position "cn=custom attributes,cn=univention,$ldap_base" \
-  --set name=owncloud
-
-univention-directory-manager settings/extended_attribute create "$@" \
-  --position "cn=owncloud,cn=custom attributes,cn=univention,$ldap_base" --set module="users/user" \
-  --set ldapMapping='ownCloudEnabled' \
-  --set objectClass='ownCloudUser' \
-  --set name='ownCloudUserEnabled' \
-  --set shortDescription='ownCloud enabled' \
-  --set longDescription='Wether User may use ownCloud ' \
-  --set translationShortDescription='"de_DE" "ownCloud aktiviert"' \
-  --set translationLongDescription='"de_DE" "Der User darf ownCloud verwenden"' \
-  --set tabName='ownCloud' \
-  --set translationTabName='"de_DE" "ownCloud"' \
-  --set overwriteTab='0' \
-  --set valueRequired='0' \
-  --set CLIName='owncloudEnabled' \
-  --set syntax='boolean' \
-  --set default="$owncloud_user_enabled" \
-  --set tabAdvanced='1' \
-  --set mayChange='1' \
-  --set multivalue='0' \
-  --set deleteObjectClass='0' \
-  --set tabPosition='1' \
-  --set overwritePosition='0' \
-  --set doNotSearch='0' \
-  --set hook='None' || \
-  univention-directory-manager settings/extended_attribute modify "$@" \
-  --dn "cn=ownCloudUserEnabled,cn=owncloud,cn=custom attributes,cn=univention,$ldap_base" \
-  --set tabAdvanced='1' \
-  --set default="$owncloud_user_enabled"
-
-univention-directory-manager settings/extended_attribute create "$@" \
-  --position "cn=owncloud,cn=custom attributes,cn=univention,$ldap_base" --set module="users/user" \
-  --set ldapMapping='ownCloudQuota' \
-  --set objectClass='ownCloudUser' \
-  --set name='ownCloudUserQuota' \
-  --set shortDescription='ownCloud Quota' \
-  --set longDescription='How much disk space may the user use' \
-  --set translationShortDescription='"de_DE" "ownCloud Quota"' \
-  --set translationLongDescription='"de_DE" "Wie viel Speicherplatz darf der User verwenden"' \
-  --set tabName='ownCloud' \
-  --set translationTabName='"de_DE" "ownCloud"' \
-  --set overwriteTab='0' \
-  --set valueRequired='0' \
-  --set CLIName='owncloudQuota' \
-  --set syntax='string' \
-  --set default="$owncloud_user_quota" \
-  --set tabAdvanced='1' \
-  --set mayChange='1' \
-  --set multivalue='0' \
-  --set deleteObjectClass='0' \
-  --set tabPosition='1' \
-  --set overwritePosition='0' \
-  --set doNotSearch='0' \
-  --set hook='None' || \
-  univention-directory-manager settings/extended_attribute modify "$@" \
-  --dn "cn=ownCloudUserQuota,cn=owncloud,cn=custom attributes,cn=univention,$ldap_base" \
-  --set tabAdvanced='1'
-
-univention-directory-manager settings/extended_attribute create "$@" \
-  --position "cn=owncloud,cn=custom attributes,cn=univention,$ldap_base" --set module="groups/group" \
-  --set ldapMapping='ownCloudEnabled' \
-  --set objectClass='ownCloudGroup' \
-  --set name='ownCloudGroupEnabled' \
-  --set shortDescription='ownCloud enabled' \
-  --set longDescription='Wether Group may be used in ownCloud ' \
-  --set translationShortDescription='"de_DE" "ownCloud aktiviert"' \
-  --set translationLongDescription='"de_DE" "Die Gruppe in ownCloud verwenden"' \
-  --set tabName='ownCloud' \
-  --set translationTabName='"de_DE" "ownCloud"' \
-  --set overwriteTab='0' \
-  --set valueRequired='0' \
-  --set CLIName='owncloudEnabled' \
-  --set syntax='boolean' \
-  --set default="$owncloud_group_enabled" \
-  --set tabAdvanced='0' \
-  --set mayChange='1' \
-  --set multivalue='0' \
-  --set deleteObjectClass='0' \
-  --set tabPosition='1' \
-  --set overwritePosition='0' \
-  --set doNotSearch='0' \
-  --set hook='None' || \
-  univention-directory-manager settings/extended_attribute modify "$@" \
-  --dn "cn=ownCloudGroupEnabled,cn=owncloud,cn=custom attributes,cn=univention,$ldap_base" \
-  --set tabAdvanced='1'
 
 OWNCLOUD_PERM_DIR="/var/lib/univention-appcenter/apps/owncloud"
 OWNCLOUD_DATA="${OWNCLOUD_PERM_DIR}/data"

--- a/05-unjoin.sh
+++ b/05-unjoin.sh
@@ -43,9 +43,6 @@ ucr unset \
   ${OVBASE}/link \
   ${OVBASE}/priority
   
-udm container/cn remove "$@" --dn "cn=owncloud,cn=custom
-attributes,cn=univention,$(ucr get ldap/base)"
-
 echo "[05.UNJOIN] Dropping ownCloud database..." 2>&1 | tee --append /var/lib/univention-appcenter/apps/owncloud/data/files/owncloud-appcenter.log
 mysql -u root -p$(cat /etc/mysql.secret) owncloud -e "DROP DATABASE IF EXISTS owncloud"
 

--- a/owncloud.attributes
+++ b/owncloud.attributes
@@ -1,0 +1,96 @@
+[owncloudUser]
+Type=ExtendedOption
+Module=users/user,settings/usertemplate
+ObjectClass=ownCloudUser
+Default=@%@owncloud/user/enabled@%@
+Editable=1
+Description=ownCloud
+LongDescription=User can use ownCloud
+DescriptionDE=ownCloud
+LongDescriptionDE=Der User darf ownCloud verwenden
+BelongsTo=ownCloudUser
+
+[ownCloudUserEnabled]
+Type=ExtendedAttribute
+Module=users/user,settings/usertemplate
+LdapMapping=ownCloudEnabled
+BelongsTo=ownCloudUser
+Description=ownCloud enabled
+LongDescription=User can use ownCloud
+DescriptionDE=ownCloud aktiviert
+LongDescriptionDE=Der User darf ownCloud verwenden
+TabName=ownCloud
+TabNameDE=ownCloud
+OverwriteTab=0
+Required=0
+CliName=owncloudEnabled
+UdmSyntax=boolean
+DisableWeb=1
+Default=1
+Advanced=0
+Options=owncloudUser
+MayChange=1
+DeleteObjectClass=1
+TabPosition=1
+DontSearch=0
+
+[ownCloudUserQuota]
+Type=ExtendedAttribute
+Module=users/user,settings/usertemplate
+LdapMapping=ownCloudQuota
+BelongsTo=ownCloudUser
+Description=ownCloud Quota
+LongDescription=How much disk space may the user use
+DescriptionDE=ownCloud Quota
+LongDescriptionDE=Wie viel Speicherplatz darf der User verwenden
+TabName=ownCloud
+TabNameDE=ownCloud
+GroupName=Quota Settings
+GroupNameDE=Quota-Einstellungen
+OverwriteTab=0
+Required=0
+CliName=owncloudQuota
+UdmSyntax=string
+Default=@%@owncloud/user/quota@%@
+Advanced=0
+Options=owncloudUser
+MayChange=1
+DeleteObjectClass=0
+TabPosition=1
+DontSearch=0
+
+[owncloudGroup]
+Type=ExtendedOption
+ObjectClass=ownCloudGroup
+Module=groups/group
+Default=@%@owncloud/group/enabled@%@
+Editable=1
+Description=ownCloud
+LongDescription=Wether Group may be used in ownCloud
+DescriptionDE=ownCloud
+LongDescriptionDE=Die Gruppe in ownCloud verwenden
+BelongsTo=ownCloudGroup
+
+[ownCloudGroupEnabled]
+Type=ExtendedAttribute
+Module=groups/group
+LdapMapping=ownCloudEnabled
+BelongsTo=ownCloudGroup
+Description=ownCloud enabled
+LongDescription=Wether Group may be used in ownCloud
+DescriptionDE=ownCloud aktiviert
+LongDescriptionDE=Die Gruppe in ownCloud verwenden
+TabName=ownCloud
+TabNameDE=ownCloud
+OverwriteTab=0
+Required=0
+CliName=owncloudEnabled
+UdmSyntax=boolean
+DisableWeb=1
+Default=0
+Advanced=0
+Options=owncloudGroup
+MayChange=1
+DeleteObjectClass=1
+TabPosition=1
+DontSearch=0


### PR DESCRIPTION
Dear owncloud,

I adjusted the owncloud joinscript for UCS 4.4 where we want to display the user settings on specific App-Tabs.
See [Screenshot](https://forge.univention.org/bugzilla/attachment.cgi?id=9830) and [Bugzilla entry 48621](https://forge.univention.org/bugzilla/show_bug.cgi?id=48621).

Best regards
Florian