### PR TITLE
Sync app settings; Issue #82

### DIFF
--- a/app-settings.ini
+++ b/app-settings.ini
@@ -8,6 +8,8 @@ Type = String
 InitialValue = ""
 Required = false
 Show = Settings
+Group = Licence
+Group[de] = Lizenz
 
 [OWNCLOUD_MARKETPLACE_APIKEY]
 Description = OwnCloud marketplace API key
@@ -16,6 +18,76 @@ Type = String
 InitialValue = ""
 Required = false
 Show = Settings
+Group = Licence
+Group[de] = Lizenz
+
+[OWNCLOUD_OPENID_LOGIN_ENABLED]
+Description = Enable or disable the OpenID Connect login for ownCloud. Note: The App "OpenID Connect Provider" has to be installed in the UCS domain. If ownCloud is not running on DC Master or Backup, check and run the ownCloud joinscript after enabling this option for the first time.
+Description[de] = Den OpenID Connect Login für ownCloud aktivieren und deaktiveren. Hinweis: Die App "OpenID Connect Provider" muss dafür in der UCS Domäne konfiguriert sein. Wenn ownCloud nicht auf einem DC Master oder Backup läuft, muss das ownCloud Joinscript nach dem erstmaligen Aktivieren dieser Option erneut ausgeführt werden.
+Type = Bool
+InitialValue = false
+Required = false
+Show = Settings
+Group = OpenID Connect
+
+[OWNCLOUD_OPENID_PROVIDER_URL]
+Description = URL where the OpenID Connect provider can be reached.
+Description[de] = URL unter der der OpenID Connect Provider erreicht werden kann.
+Type = String
+InitialValue = https://@%@ucs/server/sso/fqdn@%@/
+Required = false
+Show = Settings
+Group = OpenID Connect
+
+[OWNCLOUD_OPENID_LOGIN_BUTTON_NAME]
+Description = Text on the button used for OpenID Connect login at the ownCloud login screen
+Description[de] = Text, der auf dem Button für den OpenID Connect login auf dem ownCloud Loginfenster angezeigt wird
+Type = String
+InitialValue = Single Sign-On Login
+Required = false
+Show = Settings
+Group = OpenID Connect
+
+[OWNCLOUD_OPENID_AUTO_REDIRECT_TO_IDP]
+Description = When enabled, automatically redirect to login at the OpenID Connect IdP from the ownCloud login screen
+Description[de] = Wenn aktiviert, wird automatisch zur Anmeldung am OpenID Connect IdP vom ownCloud-Anmeldebildschirm umgeleitet
+Type = Bool
+InitialValue = false
+Required = false
+Show = Settings
+Group = OpenID Connect
+
+[OWNCLOUD_OPENID_CLIENT_ID]
+Description = OwnCloud OpenID Connect client ID.
+Description[de] = OwnCloud OpenID Connect client ID.
+InitialValue = owncloud
+Required = false
+Show = Settings
+Group = OpenID Connect
+
+[OWNCLOUD_OPENID_CLIENT_SECRET]
+Description = OwnCloud OpenID Connect shared secret.
+Description[de] = OwnCloud OpenID Connect shared secret.
+InitialValue = AVeryLongStringThatGetsSetDuringInstallation
+Required = false
+Show = Settings
+Group = OpenID Connect
+
+[OWNCLOUD_OPENID_SEARCH_MODE]
+Description = Defines the search mode in ownCloud - search can be for email and user id - default: email
+Description[de] = Definiert den Suchmodus in ownCloud. Es kann email oder die user id angegeben werden. Standardwert: email
+InitialValue = email
+Required = false
+Show = Settings
+Group = OpenID Connect
+
+[OWNCLOUD_OPENID_SEARCH_CLAIM]
+Description = Defines the claim which is taken from the userinfo endpoint to be used when searching in the ownCloud accounts for the user - default: email
+Description[de] = Definiert den claim, der vom userinfo-Endpunkt übernommen wird und bei der Suche nach dem Benutzer in den ownCloud-Konten verwendet werden soll - Standard: email
+InitialValue = email
+Required = false
+Show = Settings
+Group = OpenID Connect
 
 [OWNCLOUD_DEFAULT_LANGUAGE]
 Description = Configure the ownCloud default language. Valid values: 'en', 'de', 'fr', ...
@@ -32,14 +104,16 @@ Type = String
 InitialValue = @%@hostname@%@.@%@domainname@%@
 Required = false
 Show = Settings
+Scope = inside, outside
 
 [OWNCLOUD_SUB_URL]
-Description = Setting for OWNCLOUD_SUB_URL env variable. Together with DOMAIN this defines the owncloud setting overwrite.cli.url. This setting also configues the htaccess.RewriteBase option. (default: /owncloud)
+Description = Setting for OWNCLOUD_SUB_URL env variable. Together with DOMAIN this defines the ownCloud setting overwrite.cli.url. This setting also configues the htaccess.RewriteBase option. (default: /owncloud)
 Description[de] = Einstellung für die OWNCLOUD_SUB_URL env Variable. Zusammen mit der Einstellung DOMAIN wird die Option overwrite.cli.url gesetzt. Diese Einstellung konfiguriert außerdem die Option htaccess.RewriteBase. (Standard: /owncloud)
 Type = String
 InitialValue = /owncloud
 Required = false
 Show = Settings
+Scope = inside, outside
 
 [OWNCLOUD_LOG_LEVEL]
 Description = Configure the ownCloud Log Level. Valid values are 0, 1, 2, 3, 4.
@@ -65,26 +139,31 @@ InitialValue = false
 Required = false
 Show = Settings
 
-[OWNCLOUD_OPENID_PROVIDER_URL]
-Description = URL where the OpenID Connect provider can be reached.
-Description[de] = URL unter der der OpenID Connect Provider erreicht werden kann.
+[OWNCLOUD_USERSYNC_LISTENER]
+Description = A listener module triggers usersync when a new user is created in UCS. When disabling the option and restarting the univention-directory-listener service, new users get synchronized by a cronjob, running every 10 minutes
+Description[de] = Ein Listenermodul startet die Bentzersynchronisation wenn ein neuer Benutzer in UCS angelegt wurde. Wenn die Option abgeschaltet ist und der univention-directory-listener Dienst neugestartet wurde, werden Benutzer alle 10 Minuten von einem Cronjob synchronisiert
 Type = String
-InitialValue = "https://localhost"
+InitialValue = true
 Required = false
 Show = Settings
+Scope = outside
 
-[OWNCLOUD_OPENID_CLIENT_ID]
-Description = OwnCloud OpenID Connect client ID.
-Description[de] = OwnCloud OpenID Connect client ID.
-Type = String
-InitialValue = owncloud
+[OWNCLOUD_SYNC_DISABLE_MODE]
+Description = How should deactivated users be handled? They can be disabled in owncloud, or the account and all files can be removed from owncloud.
+Description[de] = Wie sollen deaktivierte Bentzer behandelt werden? Sie können in owncloud deaktiviert werden, oder der Account und alle Datien können gelöscht werden.
+InitialValue = disable
+Type = List
+Values = disable, remove
+Label = Disable, Remove
 Required = false
 Show = Settings
+Group = Sync
 
-[OWNCLOUD_OPENID_CLIENT_SECRET]
-Description = OwnCloud OpenID Connect shared secret.
-Description[de] = OwnCloud OpenID Connect shared secret.
-Type = String
-InitialValue = AVeryLongStringThatGetsSetDuringInstallation
+[OWNCLOUD_SYNC_ACCOUNT_REACTIVATION]
+Description = This setting defines if a user account in owncloud is reactivated, if the user is activated in UCS.
+Description[de] = Diese Einstellung bestimmt, ob Benutzeraccount in owncloud erneut aktiviert wird, wenn der Benutzer in UCS für owncloud aktiviert wird.
+InitialValue = true
+Type = Bool
 Required = false
 Show = Settings
+Group = Sync

--- a/listener_trigger
+++ b/listener_trigger
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+# run by appcenter listener inside the app container when a user is modified
+from glob import glob
+import sys
+import os
+import os.path
+import subprocess
+
+
+def main(debug=False):
+	files = glob('/var/lib/univention-appcenter/apps/owncloud/data/listener/*.json')
+	if files:
+		for fname in files:
+			if debug:
+				print(u'Deleting ', fname)
+			os.unlink(fname)
+		cmd = [u'/usr/bin/univention-owncloud-sync-ldap.sh']
+		try:
+			if debug:
+				print(u'running ', cmd)
+			subprocess.run(cmd, capture_output=True)
+		except subprocess.CalledProcessError as e:
+			print(u'Error while calling user:sync: ', e)
+			return False
+	return True
+
+
+if not main():
+	sys.exit(1)

--- a/univention-owncloud-sync-ldap.sh
+++ b/univention-owncloud-sync-ldap.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# should be placed in /usr/bin/
+# otherwise, the listener_trigger script and the owncloud sync cronjob has to be adapted
+
+source /etc/entrypoint.d/05-univention-env.sh
+
+MODE="${OWNCLOUD_SYNC_DISABLE_MODE}"
+if [ -z "$MODE" ]; then
+	MODE="disable"
+fi
+
+REACTIVATE=
+if [ "$OWNCLOUD_SYNC_ACCOUNT_REACTIVATION" == "true" ]; then
+	REACTIVATE="-r"
+fi
+
+/usr/bin/occ user:sync -m $MODE $REACTIVATE 'OCA\User_LDAP\User_Proxy'


### PR DESCRIPTION
Configure sync mode (disable or remove users) by app setting
Configure user reactivation mode by app setting

New sync script univention-owncloud-sync-ldap.sh does the actual sync
and sources the app center integration ENV file.

Adapted the listener script to call the new sync script.

TODO: For this to work, the owncloud appliance docker image has to be
adapted.
* Place univention-owncloud-sync-ldap.sh in /usr/bin
* Modify owncloud sync cronjob to call this new script, instead of
doing the current hardcoded sync call